### PR TITLE
Fix for direnv changes to status values

### DIFF
--- a/envrc-plugin/build.gradle.kts
+++ b/envrc-plugin/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
 }
 
 group = "dev.smithers"
-version = "0.0.3"
+version = "0.0.4"
 
 gradlePlugin {
     plugins {

--- a/envrc-plugin/src/main/kotlin/dev/smithers/GradleEnvrcPlugin.kt
+++ b/envrc-plugin/src/main/kotlin/dev/smithers/GradleEnvrcPlugin.kt
@@ -34,7 +34,7 @@ private class EnvrcFile {
         val dollar = "\$"
         val script = """
                 if command -v direnv > /dev/null; then
-                    if ! direnv status | grep --quiet 'RC allowed true'; then
+                    if ! direnv status | grep --quiet 'RC allowed true\|RC allowed 0'; then
                         echo -n $SPECIAL_BLOCKED_VALUE
                         exit
                     fi


### PR DESCRIPTION
Fixes jonsmithers/gradle-envrc#1

Somewhere back in 2023/2024 direnv changed from returning `true` when a .env file has been allowed, to returning `0`. This is especially confusing because 0 would typically indicate false, but I've tested and confirmed that it equates to true here. 

This change should support both the old direnv response as well as the new. 